### PR TITLE
fix(replayer): give handlers time to receive events and update settled state #2

### DIFF
--- a/lib/w3ws/replayer.ex
+++ b/lib/w3ws/replayer.ex
@@ -242,6 +242,9 @@ defmodule W3WS.Replayer do
     end
 
     defp wait_until_handler_settled(handler, state) do
+      # give handlers a moment to receive events and update their settled state.
+      Process.sleep(10)
+
       if W3WS.Handler.settled?(handler, state) do
         :ok
       else

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule W3Events.MixProject do
   def project do
     [
       app: :w3ws,
-      version: "0.3.0",
+      version: "0.3.1",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
fixes: #2 